### PR TITLE
CPU Emulator: Fix wrong jump target

### DIFF
--- a/SimulatorsPackage/src/main/java/Hack/CPUEmulator/CPU.java
+++ b/SimulatorsPackage/src/main/java/Hack/CPUEmulator/CPU.java
@@ -51,7 +51,7 @@ public class CPU
     // The time that passed since the program started running.
     protected long time;
 
-    // An assembler transltor
+    // An assembler translator
     protected HackAssemblerTranslator assemblerTranslator;
 
     /**
@@ -161,8 +161,8 @@ public class CPU
             bus.send(rom, PC.get(), A, 0);
         else if ((instruction & 0xe000) == 0xe000) {
             computeExp(instruction);
-            setDestination(instruction);
             pcChanged = checkJump(instruction);
+            setDestination(instruction);
         }
         else if (instruction != HackAssemblerTranslator.NOP)
             throw new ProgramException("At line " + PC.get() +


### PR DESCRIPTION
Bugfix: The A Register was wrongly updated before deriving the jump target. The jump target should be based on the value in A before executing the jump instruction.

Example:
@1234
A=0;JMP // should jump to 1234, not to 0

The corrected behavior is in line with the Hardware Simulator.

See here:
http://nand2tetris-questions-and-answers-forum.52.s1.nabble.com/Subtle-different-behaviors-between-the-CPU-emulator-and-the-proposed-CPU-design-td4034781.html